### PR TITLE
Fixing LVS issue

### DIFF
--- a/config.tcl
+++ b/config.tcl
@@ -24,8 +24,8 @@ set ::env(PL_TARGET_DENSITY) [ expr ($::env(FP_CORE_UTIL)+5) / 100.0 ]
 # don't put clock buffers on the outputs, need tristates to be the final cells
 set ::env(PL_RESIZER_BUFFER_OUTPUT_PORTS) 0
 
-set ::env(PL_RESIZER_HOLD_SLACK_MARGIN) 0.2
-set ::env(GLB_RESIZER_HOLD_SLACK_MARGIN) 0.2
+set ::env(PL_RESIZER_HOLD_SLACK_MARGIN) 0.1
+set ::env(GLB_RESIZER_HOLD_SLACK_MARGIN) 0.1
 
 # set absolute size of the die to 300 x 300 um
 #set ::env(DIE_AREA) "0 0 600 600"

--- a/wrapper.v
+++ b/wrapper.v
@@ -189,7 +189,7 @@ module wrapped_spraid(
 		.wb_ack_o(buf_wbs_ack_o),
 		.wb_adr_i(wbs_adr_i),
 		.wb_cyc_i(wbs_cyc_i),
-		.wb_sel_i(wbs_sel_i),
+//		.wb_sel_i(wbs_sel_i),
 		.wb_stb_i(wbs_stb_i),
 		.wb_we_i(wbs_we_i),
 	


### PR DESCRIPTION
	- LVS issue with non matching connections due to not using
	  wb_sel_i. Commented out in wrapper.v and
	  spraid/src/wb_spraid.v
	- Reverted buffering to 0.1 in config.tcl